### PR TITLE
Only run publish workflow on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,6 @@
 name: Publish
 
 on:
-  push:
-  pull_request:
   release:
     types:
       - published


### PR DESCRIPTION
## Description

This PR updates the `publish.yml` workflow to run only when a new release is published. I've removed the triggers for pull requests and pushes to the main branch, focusing the workflow solely on the release process.

Note: With this change, someone with the necessary permissions will need to create a new tag or release to trigger the publish workflow. This ensures that we only publish new versions of Giraffe.OpenApi when explicitly releasing a new version.