### PR TITLE
Set PrivateAssets=all for Microsoft.SourceLink.GitHub in the project…

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.1.8" />
     <PackageVersion Include="FSharp.Core" Version="8.0.300" />
     <!-- Giraffe.OpenApi -->
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.11" />
     <!-- Sample App -->
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0" />

--- a/src/Giraffe.OpenApi/Giraffe.OpenApi.fsproj
+++ b/src/Giraffe.OpenApi/Giraffe.OpenApi.fsproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="Giraffe" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
… file, rather than in Directory.Packages.props

I was just having a look at the NuGet package and noticed that it has a dependency on ```Microsoft.SourceLink.GitHub``` and I didn't think it should?

![image](https://github.com/user-attachments/assets/92d8d984-50ff-45ee-8c49-524005010e0a)

Saying that, as it's built with the .NET 8 SDK it might be able to just use the built in SourceLink and not need the NuGet package.