### PR TITLE
Allow named path parameters in swagger and remove request body for tuple request types

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,12 +4,12 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Common -->
-    <PackageVersion Include="Giraffe" Version="7.0.2" />
-    <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.1.8" />
-    <PackageVersion Include="FSharp.Core" Version="8.0.300" />
+    <PackageVersion Include="Giraffe" Version="8.0.0-alpha-003" />
+    <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.2.0" />
+    <PackageVersion Include="FSharp.Core" Version="8.0.403" />
     <!-- Giraffe.OpenApi -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.17" />
     <!-- Sample App -->
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="8.1.4" />
     <!-- Analyzers -->

--- a/sample-project/Program.fs
+++ b/sample-project/Program.fs
@@ -1,4 +1,4 @@
-﻿open System
+open System
 open System.IO
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Http
@@ -25,7 +25,14 @@ let handler1 (_: HttpFunc) (ctx: HttpContext) = ctx.WriteTextAsync "Hello World"
 let handler2 (firstName: string, age: int) (_: HttpFunc) (ctx: HttpContext) =
     $"Hello %s{firstName}, you are %i{age} years old." |> ctx.WriteTextAsync
 
+let handler3 (firstName: string) (_: HttpFunc) (ctx: HttpContext) =
+    $"Hello %s{firstName}!" |> ctx.WriteTextAsync
+
+/// Redirects to the swagger interface from the root of the site.
+let swaggerRedirectHandler : HttpHandler = redirectTo true "swagger/index.html"
+
 let endpoints = [
+    route "/" swaggerRedirectHandler
     GET [
         route "/hello" (json { Hello = "Hello from Giraffe" })
         |> configureEndpoint _.WithTags("SampleApp")
@@ -33,11 +40,17 @@ let endpoints = [
         |> configureEndpoint _.WithDescription("Will return a Hello from Giraffe.")
         |> addOpenApiSimple<unit, FsharpMessage>
 
-        routef "/%s/%i" handler2
+        routef "first-names/%s:firstName/ages/%i:age" handler2
         |> configureEndpoint _.WithTags("SampleApp")
         |> configureEndpoint _.WithSummary("Fetches a response from handler2")
         |> configureEndpoint _.WithDescription("Will return a Hello from Handler 2.")
         |> addOpenApiSimple<string * int, string>
+
+        routef "names/%s:firstName" handler3
+        |> configureEndpoint _.WithTags("SampleApp")
+        |> configureEndpoint _.WithSummary("Fetches a response from handler3")
+        |> configureEndpoint _.WithDescription("Will return a Hello from Handler 3.")
+        |> addOpenApiSimple<string, string>
     ]
     POST [
         route "/message" (text "Message posted!")

--- a/sample-project/packages.lock.json
+++ b/sample-project/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "Giraffe": {
         "type": "Direct",
-        "requested": "[7.0.2, )",
-        "resolved": "7.0.2",
-        "contentHash": "AwUqNORb9OmsqIGTAmbQtZBHoWz0yxACHA/xJqby3usUaqBUmrcz5dflVzPWUvqkulWPntwdRkQlzdt9zeEr6Q==",
+        "requested": "[8.0.0-alpha-003, )",
+        "resolved": "8.0.0-alpha-003",
+        "contentHash": "q+FSYgPeq4tifAR3wHgFMDa4dCa4Xv2/XeMHQ19uXZwP8SOnkEh0GyukDumjxQLou3cD1OjF6ox498k+fOnWbg==",
         "dependencies": {
           "FSharp.Core": "6.0.0",
           "FSharp.SystemTextJson": "1.3.13",
@@ -106,21 +106,21 @@
       "giraffe.openapi": {
         "type": "Project",
         "dependencies": {
-          "Giraffe": "[7.0.2, )",
-          "Microsoft.AspNetCore.OpenApi": "[8.0.16, )"
+          "Giraffe": "[8.0.0-alpha-003, )",
+          "Microsoft.AspNetCore.OpenApi": "[8.0.17, )"
         }
       },
       "FSharp.Core": {
         "type": "CentralTransitive",
-        "requested": "[8.0.300, )",
+        "requested": "[8.0.403, )",
         "resolved": "6.0.0",
         "contentHash": "fbv1UwJ2LXVcFCt+GGDPu0sIYA5C6gdDvAupDj3iLQF3clRkua/6J33f+FiGQa8P1tEa+zmz3wrjoTnXZ1UiYg=="
       },
       "Microsoft.AspNetCore.OpenApi": {
         "type": "CentralTransitive",
-        "requested": "[8.0.16, )",
-        "resolved": "8.0.16",
-        "contentHash": "jeZBYi62BKGRZXEkXAr9hj1L6u71HRKE7EPaZBouF1xmKdQIX7GO5oSRLTQLQmmST0y/aaI+Mr4OzyyRjmBFog==",
+        "requested": "[8.0.17, )",
+        "resolved": "8.0.17",
+        "contentHash": "sGed2RDkJYAoi7N4gUTota56Mix/Vu6UrzCWdwqH1jZwnLnZb+eP2zdABYCaVlBEHBwzuL1zchUFtJXW4lO5LA==",
         "dependencies": {
           "Microsoft.OpenApi": "1.4.3"
         }

--- a/src/Giraffe.OpenApi/Routing.fs
+++ b/src/Giraffe.OpenApi/Routing.fs
@@ -1,4 +1,4 @@
-﻿namespace Giraffe.OpenApi
+namespace Giraffe.OpenApi
 
 // Modified for Giraffe, from https://github.com/Lanayx/Oxpecker/blob/develop/src/Oxpecker.OpenApi/Routing.fs.
 //
@@ -25,6 +25,7 @@
 // SOFTWARE.
 
 open System.Reflection
+open FSharp.Reflection
 
 [<AutoOpen>]
 module Routing =
@@ -84,7 +85,8 @@ module Routing =
             | reqType, respType when reqType = unitType && respType = unitType -> "InvokeUnit"
             | reqType, _ when reqType = unitType -> "InvokeUnitReq"
             | _, respType when respType = unitType -> "InvokeUnitResp"
-            | _, _ -> "Invoke"
+            | reqType, _ when FSharpType.IsTuple reqType -> "InvokeUnitReq"
+            | _ -> "Invoke"
         configureEndpoint
             _.WithMetadata(
                 typeof<FakeFunc<'Req, 'Res>>

--- a/src/Giraffe.OpenApi/packages.lock.json
+++ b/src/Giraffe.OpenApi/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "Giraffe": {
         "type": "Direct",
-        "requested": "[7.0.2, )",
-        "resolved": "7.0.2",
-        "contentHash": "AwUqNORb9OmsqIGTAmbQtZBHoWz0yxACHA/xJqby3usUaqBUmrcz5dflVzPWUvqkulWPntwdRkQlzdt9zeEr6Q==",
+        "requested": "[8.0.0-alpha-003, )",
+        "resolved": "8.0.0-alpha-003",
+        "contentHash": "q+FSYgPeq4tifAR3wHgFMDa4dCa4Xv2/XeMHQ19uXZwP8SOnkEh0GyukDumjxQLou3cD1OjF6ox498k+fOnWbg==",
         "dependencies": {
           "FSharp.Core": "6.0.0",
           "FSharp.SystemTextJson": "1.3.13",
@@ -35,9 +35,9 @@
       },
       "Microsoft.AspNetCore.OpenApi": {
         "type": "Direct",
-        "requested": "[8.0.16, )",
-        "resolved": "8.0.16",
-        "contentHash": "jeZBYi62BKGRZXEkXAr9hj1L6u71HRKE7EPaZBouF1xmKdQIX7GO5oSRLTQLQmmST0y/aaI+Mr4OzyyRjmBFog==",
+        "requested": "[8.0.17, )",
+        "resolved": "8.0.17",
+        "contentHash": "sGed2RDkJYAoi7N4gUTota56Mix/Vu6UrzCWdwqH1jZwnLnZb+eP2zdABYCaVlBEHBwzuL1zchUFtJXW4lO5LA==",
         "dependencies": {
           "Microsoft.OpenApi": "1.4.3"
         }
@@ -96,7 +96,7 @@
       },
       "FSharp.Core": {
         "type": "CentralTransitive",
-        "requested": "[8.0.300, )",
+        "requested": "[8.0.403, )",
         "resolved": "6.0.0",
         "contentHash": "fbv1UwJ2LXVcFCt+GGDPu0sIYA5C6gdDvAupDj3iLQF3clRkua/6J33f+FiGQa8P1tEa+zmz3wrjoTnXZ1UiYg=="
       }


### PR DESCRIPTION
### Description

- Update build dependencies, specifically Giraffe to 8.0.0-alpha-003 which implemented path parameter labels.
- Fix issue where using multiple path parameters AND `addOpenApiSimple`, which requires a tuple for the request type, caused a request body to be required despite all parameters being in path.
- Add cases to sample project.
- Update sample project to redirect to Swagger UI upon startup.
- Update README with additional details around `addOpenApiSimple`